### PR TITLE
perf/breaking-change: optimize tunnel connection

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -89,6 +89,7 @@ enum ClientActions {
 #[derive(Subcommand)]
 enum ServerActions {
     Run {
+        // TODO: add option to flush all requests from redis
         #[arg(long)]
         host: Option<String>,
         #[arg(long, default_value_t = 8000)]

--- a/client/src/data/repository/underlying_repo.rs
+++ b/client/src/data/repository/underlying_repo.rs
@@ -22,7 +22,9 @@ impl UnderlyingRepo for UnderlyingRepoImpl {
     async fn forward(&self, request: Vec<u8>, host: String) -> Result<Vec<u8>, String> {
         //info!("Forwarding request: {} to host: {}", String::from_utf8(request.clone()).unwrap(), host.clone());
         let stream = TcpStream::connect(host.as_str()).await.unwrap();
-        let mut stream = TcpStreamTLS::from_tcp(stream);
+        let (read_stream, write_stream) = tokio::io::split(stream);
+        let mut stream = TcpStreamTLS::from_tcp(read_stream, write_stream);
+        
         // forward request
         stream.write_all(&request).await.unwrap();
         

--- a/client/src/handler/main_handler.rs
+++ b/client/src/handler/main_handler.rs
@@ -160,7 +160,7 @@ pub async fn tunnel_receiver_handler(stream: Arc<Mutex<TcpStreamTLS>>, tx: Arc<M
         }
     }
 
-    error!("Connection closed.");
+    info!("Tunnel receiver handler stopped.");
 }
 
 pub async fn tunnel_sender_handler(stream: Arc<Mutex<TcpStreamTLS>>, rx: Arc<Mutex<Receiver<PublicResponse>>>) {
@@ -193,5 +193,5 @@ pub async fn tunnel_sender_handler(stream: Arc<Mutex<TcpStreamTLS>>, rx: Arc<Mut
         }
     }
 
-    error!("Connection closed.");
+    info!("Tunnel sender handler stopped.");
 }

--- a/client/src/handler/main_handler.rs
+++ b/client/src/handler/main_handler.rs
@@ -1,5 +1,3 @@
-// TODO: implement this
-
 use std::{sync::Arc, time::Duration};
 
 use http::StatusCode;
@@ -7,10 +5,12 @@ use http::StatusCode;
 use common::{
     convert::{from_json_slice, to_json_vec}, 
     data::dto::{public_request::PublicRequest, public_response::PublicResponse, tunnel_client::TunnelClient}, 
-    net::{ack_health_check_packet, http_json_response_as_bytes, read_bytes_from_mutexed_socket, read_string_from_socket, HttpResponse, TcpStreamTLS}, 
+    net::{
+        http_json_response_as_bytes, prepare_packet, read_bytes_from_mutexed_socket, read_string_from_socket, separate_packets, HttpResponse, TcpStreamTLS, HEALTH_CHECK_PACKET_ACK
+    }, 
     security::sign_value
 };
-use tokio::{net::TcpStream, sync::Mutex, time::{sleep, Instant}};
+use tokio::{net::TcpStream, sync::{Mutex, mpsc, mpsc::{Sender, Receiver}}, time::{sleep, Instant}};
 use log::{error, info};
 use tokio_native_tls::{native_tls, TlsConnector};
 
@@ -40,7 +40,7 @@ pub async fn register_handler(underlying_host: String, service: UnderlyingServic
                 continue;
             }
         };
-        let mut stream = if use_tls {
+        let (mut read_stream, mut write_stream) = if use_tls {
             let cert = get_ca_certificate().unwrap();
             let connector = native_tls::TlsConnector::builder()
                 .add_root_certificate(cert)
@@ -48,30 +48,26 @@ pub async fn register_handler(underlying_host: String, service: UnderlyingServic
                 .unwrap();
             let connector = TlsConnector::from(connector);
             let tls_stream = connector.connect(server_host.as_str(), tcp_stream).await.unwrap();
+            let (read_stream, write_stream) = tokio::io::split(tls_stream);
             info!("TLS Bound -> address: {}", server_address.clone());
-            TcpStreamTLS {
-                tcp: None,
-                tls: Some(tls_stream)
-            }
+            (TcpStreamTLS::from_tcp_tls_read(read_stream), TcpStreamTLS::from_tcp_tls_write(write_stream))
         } else { 
-            TcpStreamTLS {
-                tcp: Some(tcp_stream),
-                tls: None
-            }
+            let (read_stream, write_stream) = tokio::io::split(tcp_stream);
+            (TcpStreamTLS::from_tcp_read(read_stream), TcpStreamTLS::from_tcp_write(write_stream))
          };
         // send connection request to server service
         let tunnel_client = get_tunnel_client();
         let bytes_req = to_json_vec(&tunnel_client);
 
         info!("Connecting to server service...");
-        if let Err(e) = stream.write_all(&bytes_req).await {
+        if let Err(e) = write_stream.write_all(&bytes_req).await {
             error!("Error connecting to server service: {}", e);
             continue;
         }
 
         // check if the server handshake was successful
         let mut ok: String = Default::default();
-        if let Err(e) = read_string_from_socket(&mut stream, &mut ok).await {
+        if let Err(e) = read_string_from_socket(&mut read_stream, &mut ok).await {
             error!("Error connecting to server service: {}", e);
             continue;
         }
@@ -82,9 +78,31 @@ pub async fn register_handler(underlying_host: String, service: UnderlyingServic
 
         info!("Connected to server service.");
 
-        let stream_mutex = Arc::new(Mutex::new(stream));
-        // start tunnel handler
-        tunnel_handler(stream_mutex, underlying_host.clone(), service.clone()).await;
+        
+        // create channel for request queue
+        let (tx, rx) = mpsc::channel::<PublicResponse>(5);
+
+        // convert to mutex
+        let tx_mutex = Arc::new(Mutex::new(tx));
+        let rx_mutex = Arc::new(Mutex::new(rx));
+        let read_stream_mutex = Arc::new(Mutex::new(read_stream));
+        let write_stream_mutex = Arc::new(Mutex::new(write_stream));
+        
+        // TODO: add break flag if one of the handlers stopped (?)
+
+        // spawn handlers
+        let cloned_underlying_host = underlying_host.clone();
+        let cloned_service = service.clone();
+        let receiver_handler = tokio::spawn(async move {
+            tunnel_receiver_handler(read_stream_mutex, tx_mutex, cloned_underlying_host, cloned_service).await;
+        });
+        let sender_handler = tokio::spawn(async move {
+            tunnel_sender_handler(write_stream_mutex, rx_mutex).await;
+        });
+
+        // wait until released
+        receiver_handler.await.unwrap_or_default();
+        sender_handler.await.unwrap_or_default();
     }
 }
 
@@ -97,8 +115,8 @@ fn get_tunnel_client() -> TunnelClient {
     TunnelClient::new(client_id, signature)
 }
 
-pub async fn tunnel_handler(stream: Arc<Mutex<TcpStreamTLS>>, underlying_host: String, service: UnderlyingService) {
-    info!("Tunnel handler started.");
+pub async fn tunnel_receiver_handler(stream: Arc<Mutex<TcpStreamTLS>>, tx: Arc<Mutex<Sender<PublicResponse>>>, underlying_host: String, service: UnderlyingService) {
+    info!("Tunnel receiver handler started.");
     loop {
         // get incoming request server service to forward
         let mut request = Vec::new();
@@ -112,45 +130,68 @@ pub async fn tunnel_handler(stream: Arc<Mutex<TcpStreamTLS>>, underlying_host: S
             continue;
         }
 
-        if ack_health_check_packet(stream.clone(), request.clone()).await {
-            // skip if the packet
-            continue;
-        }
-
-        let public_request: PublicRequest = from_json_slice(&request).unwrap();
-        let start_request = Instant::now();
-        info!("Incoming request: {} received, forwarding to underlying service...", public_request.id);
-        // forward response to underlying service
-        let res = service.foward_request(public_request.data, underlying_host.clone()).await;
-        if res.is_err() {
-            // response error to server
-            let msg = String::from("Request cannot be processed");
-            let response = match http_json_response_as_bytes(
-                HttpResponse::new(false, msg), StatusCode::from_u16(400).unwrap()) {
-                    Ok(value) => value,
-                    Err(err) => {
-                        info!("error: {}", err);
-                        continue;
-                    } 
+        let packets = separate_packets(request);
+        for packet in packets {
+            let public_request: PublicRequest = from_json_slice(&packet).unwrap(); // assuming correct format
+            let start_request = Instant::now();
+            info!("Incoming request: {} received, forwarding to underlying service...", public_request.id);
+            
+            // dispatch request to underlying service
+            let cloned_underlying_host = underlying_host.clone();
+            let cloned_service = service.clone();
+            let cloned_tx = tx.clone();
+            tokio::spawn(async move {
+                let public_response = match cloned_service.foward_request(public_request.data, cloned_underlying_host).await {
+                    Ok(res) => {
+                        PublicResponse::new(public_request.id.clone(), res.clone())
+                    },
+                    Err(_) => {
+                        let msg = String::from("Request cannot be processed");
+                        let res = http_json_response_as_bytes(
+                            HttpResponse::new(false, msg), StatusCode::from_u16(400).unwrap()).unwrap();
+                        PublicResponse::new(public_request.id.clone(), res.clone())
+                    }
                 };
-
-            stream.lock().await.write_all(&response).await.unwrap();
-
-            continue;
-        }
-
-        info!("Response for request {} received in {} seconds.", public_request.id,start_request.elapsed().as_secs());
         
-        let res = res.unwrap();
-        let public_response = PublicResponse::new(public_request.id.clone(), res.clone());
-
-        // foward response from underlying service to server service
-        let bytes_res = to_json_vec(&public_response);
-        if let Err(e) = stream.lock().await.write_all(&bytes_res).await {
-            error!("{}", e);
-            break;
+                if let Ok(_) = cloned_tx.lock().await.send(public_response).await {
+                    info!("Response for request {} received in {} seconds and was enqueued to foward back", public_request.id, start_request.elapsed().as_secs());
+                }
+            });
         }
-
-        info!("Incoming request: {} processed.", public_request.id);
     }
+
+    error!("Connection closed.");
+}
+
+pub async fn tunnel_sender_handler(stream: Arc<Mutex<TcpStreamTLS>>, rx: Arc<Mutex<Receiver<PublicResponse>>>) {
+    info!("Tunnel sender handler started.");
+    let mut skip = 0;
+    loop {
+        // get ready public responses from the queue
+        if let Some(public_response) = rx.lock().await.recv().await {
+            info!("Response for request: {} is available.", public_response.request_id);
+            // foward response from underlying service to server service
+            let bytes_res = prepare_packet(to_json_vec(&public_response));
+            if let Err(e) = stream.lock().await.write_all(&bytes_res).await {
+                error!("{}", e);
+                break;
+            }
+
+            info!("Request: {} processed.", public_response.request_id);
+        } else {
+            skip += 1;
+            // every 20k skips send health check
+            if skip == 20000 {
+                let hc = prepare_packet(Vec::from(String::from(HEALTH_CHECK_PACKET_ACK).as_bytes()));
+                if let Err(_) = stream.lock().await.write_all(&hc).await {
+                    break;
+                }
+                // sleep for 0.5 seconds
+                sleep(Duration::from_millis(100)).await;
+                skip = 0;
+            }
+        }
+    }
+
+    error!("Connection closed.");
 }

--- a/common/src/data/dto/public_request.rs
+++ b/common/src/data/dto/public_request.rs
@@ -21,13 +21,12 @@ pub enum ReqBodyType {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct PublicRequest {
     pub id: String,
-    pub client_id: String,
     pub data: Vec<u8>
 }
 
 impl fmt::Display for PublicRequest {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Write the desired string representation of the struct
-        write!(f, "[id: {}, client_id: {})", self.id, self.client_id)
+        write!(f, "[id: {})", self.id)
     }
 }

--- a/server/src/data/repository/response_repo.rs
+++ b/server/src/data/repository/response_repo.rs
@@ -6,8 +6,8 @@ const REDIS_KEY_PUBLIC_RESPONSE: &str = "public_responses";
 
 #[async_trait]
 pub trait ResponseRepo {
-    async fn set(&self, response: PublicResponse) -> Result<(), String>;
-    async fn pop(&self, request_id: String) -> Result<PublicResponse, String>;
+    async fn set(&self, client_id: String, response: PublicResponse) -> Result<(), String>;
+    async fn pop(&self, client_id: String, request_id: String) -> Result<PublicResponse, String>;
 }
 
 pub struct ResponseRepoImpl {
@@ -22,15 +22,17 @@ impl ResponseRepoImpl {
 
 #[async_trait]
 impl ResponseRepo for ResponseRepoImpl {
-    async fn set(&self, response: PublicResponse) -> Result<(), String> {
+    async fn set(&self, client_id: String, response: PublicResponse) -> Result<(), String> {
+        let key = format!("{}_{}", REDIS_KEY_PUBLIC_RESPONSE, client_id);
         let data = to_json_vec(&response);
-        self.connection.clone().hset(REDIS_KEY_PUBLIC_RESPONSE, response.request_id.clone(), data).await
+        self.connection.clone().hset(key, response.request_id.clone(), data).await
             .map_err(|e| format!("Error setting response {}: {}", response.request_id, e))?;
         Ok(())
     }
 
-    async fn pop(&self, request_id: String) -> Result<PublicResponse, String> {
-        let data: Vec<u8> = self.connection.clone().hget(REDIS_KEY_PUBLIC_RESPONSE, request_id.clone()).await
+    async fn pop(&self, client_id: String, request_id: String) -> Result<PublicResponse, String> {
+        let key = format!("{}_{}", REDIS_KEY_PUBLIC_RESPONSE, client_id);
+        let data: Vec<u8> = self.connection.clone().hget(key.clone(), request_id.clone()).await
             .map_err(|e| format!("Error getting response {}: {}", request_id, e))?;
         if data.len() == 0 {
             return Err(String::from("Error getting response: no response available"));
@@ -38,7 +40,7 @@ impl ResponseRepo for ResponseRepoImpl {
 
         let res: PublicResponse = from_json_slice(&data).unwrap();
         // delete data
-        self.connection.clone().hdel(REDIS_KEY_PUBLIC_RESPONSE, request_id.clone()).await
+        self.connection.clone().hdel(key, request_id.clone()).await
             .map_err(|e| format!("Error deleting {}: {}", request_id, e))?;
         Ok(res)
     }

--- a/server/src/handler/public_handler.rs
+++ b/server/src/handler/public_handler.rs
@@ -15,7 +15,8 @@ use crate::service::public_service::PublicService;
 
 pub async fn register_public_handler(stream: TcpStream, service: PublicService, cache_service: CacheService) {
     tokio::spawn(async move {
-        public_handler(TcpStreamTLS::from_tcp(stream), service, cache_service).await;
+        let (read_stream, write_stream) = tokio::io::split(stream);
+        public_handler(TcpStreamTLS::from_tcp(read_stream, write_stream), service, cache_service).await;
     });
 }
 

--- a/server/src/handler/public_handler.rs
+++ b/server/src/handler/public_handler.rs
@@ -104,13 +104,12 @@ async fn public_handler(mut stream: TcpStreamTLS, service: PublicService, cache_
     }
 
     let public_request = PublicRequest {
-        client_id: client_id.clone(),
         id: request_id.clone(),
         data: raw_request
     };
 
     // enqueue the request to redis
-    if let Err(e) = service.enqueue_request(public_request).await {
+    if let Err(e) = service.enqueue_request(client_id.clone(), public_request).await {
         let response = match http_json_response_as_bytes(
         HttpResponse::new(false, e), StatusCode::from_u16(503).unwrap()) {
             Ok(value) => value,

--- a/server/src/handler/tunnel_handler.rs
+++ b/server/src/handler/tunnel_handler.rs
@@ -117,7 +117,7 @@ async fn tunnel_sender_handler(stream: Arc<Mutex<TcpStreamTLS>>, public_service:
         // request from the queue
         match public_service.lock().await.dequeue_request(client_id.clone()).await {
             Ok(public_request) => {
-                println!("Request was found: {}", public_request.id.clone());
+                info!("Request was found: {}", public_request.id.clone());
                 
                 // send request to client service
                 let bytes_req = prepare_packet(to_json_vec(&public_request.clone()));

--- a/server/src/handler/tunnel_handler.rs
+++ b/server/src/handler/tunnel_handler.rs
@@ -129,7 +129,7 @@ async fn tunnel_sender_handler(stream: Arc<Mutex<TcpStreamTLS>>, public_service:
                     }
                 };
 
-                info!("Request: {} was sent to client: {}.", public_request.id, public_request.client_id);
+                info!("Request: {} was sent to client: {}.", public_request.id, client_id.clone());
             },
             Err(_) => {
                 skip += 1;
@@ -179,7 +179,7 @@ async fn tunnel_receiver_handler(stream: Arc<Mutex<TcpStreamTLS>>, public_servic
                 }
             };
 
-            if let Err(msg) = public_service.lock().await.assign_response(response.clone()).await {
+            if let Err(msg) = public_service.lock().await.assign_response(client_id.clone(), response.clone()).await {
                 error!("{}", msg);
                 continue;
             }

--- a/server/src/handler/tunnel_handler.rs
+++ b/server/src/handler/tunnel_handler.rs
@@ -1,6 +1,6 @@
 
 use common::convert::{from_json_slice, to_json_vec};
-use common::net::{read_bytes_from_mutexed_socket, read_bytes_from_socket, send_health_check_packet, TcpStreamTLS};
+use common::net::{read_bytes_from_mutexed_socket, read_bytes_from_socket, prepare_packet, separate_packets, TcpStreamTLS, HEALTH_CHECK_PACKET_ACK};
 use common::validate_signature;
 use log::{error, info};
 use tokio::net::TcpStream;
@@ -16,10 +16,12 @@ use crate::service::public_service::PublicService;
 
 pub async fn register_tunnel_handler(stream: TcpStream, client_service: ClientService, public_service: PublicService) -> () {
     info!("Pending connection");
-    let mut stream = TcpStreamTLS::from_tcp(stream);
+    let (read_stream, write_stream) = tokio::io::split(stream);
+    let mut read_stream = TcpStreamTLS::from_tcp_read(read_stream);
+    let mut write_stream = TcpStreamTLS::from_tcp_write(write_stream);
     // register client ID
     let mut raw_response = Vec::new();
-    if let Err(e) = read_bytes_from_socket(&mut stream, &mut raw_response).await {
+    if let Err(e) = read_bytes_from_socket(&mut read_stream, &mut raw_response).await {
         error!("{}", e);
         return;
     }
@@ -30,7 +32,7 @@ pub async fn register_tunnel_handler(stream: TcpStream, client_service: ClientSe
         None => {
             let err_msg = format!("Invalid request");
             error!("{}", err_msg);
-            stream.write_all(err_msg.as_bytes()).await.unwrap();
+            write_stream.write_all(err_msg.as_bytes()).await.unwrap();
             return;    
         }
     };
@@ -39,26 +41,38 @@ pub async fn register_tunnel_handler(stream: TcpStream, client_service: ClientSe
     if !validate_connection(client.signature.clone(), client.id.clone()) {
         let err_msg = format!("Client Registration Denied. client_id: {}, signature: {}", client_id, client.signature);
         error!("{}", err_msg);
-        stream.write_all(err_msg.as_bytes()).await.unwrap();
+        write_stream.write_all(err_msg.as_bytes()).await.unwrap();
         return;
     } else {
         // acknowledge the successful handshake
         let ok = b"ok";
         let msg = format!("Client Registration Successful. client_id: {}, signature: {}", client_id, client.signature);
         info!("{}", msg);
-        stream.write_all(ok).await.unwrap();
+        write_stream.write_all(ok).await.unwrap();
     }
+
+    // sleep for 1.5 seconds to prevent race condition with healthcheck packet
+    sleep(Duration::from_millis(1500)).await;
 
     client_service.register_client(client).await.unwrap();
 
     // isolate stream and service inside Arc
-    let stream_arc = Arc::new(Mutex::new(stream));
-    let client_service_arc = Arc::new(Mutex::new(client_service));
-    let public_service_arc = Arc::new(Mutex::new(public_service));
+    let read_stream_arc = Arc::new(Mutex::new(read_stream));
+    let write_stream_arc = Arc::new(Mutex::new(write_stream));
+    let client_service_arc1 = Arc::new(Mutex::new(client_service));
+    let client_service_arc2 = client_service_arc1.clone();
+    let public_service_arc1 = Arc::new(Mutex::new(public_service));
+    let public_service_arc2 = public_service_arc1.clone();
 
-    // spawn sender handler
+    let client_id1 = client_id.clone();
+    let client_id2 = client_id.clone();
+
+    // spawn handlers
     tokio::spawn(async move {
-        tunnel_handler(stream_arc, public_service_arc, client_service_arc, client_id).await;
+        tunnel_sender_handler(write_stream_arc, public_service_arc1, client_service_arc1, client_id1).await;
+    });
+    tokio::spawn(async move {
+        tunnel_receiver_handler(read_stream_arc, public_service_arc2, client_service_arc2, client_id2).await;
     });
 }
 
@@ -67,43 +81,81 @@ fn validate_connection(signature: String, client_id: String) -> bool {
     validate_signature!(signature, client_id, secret)
 }
 
-async fn tunnel_handler(stream: Arc<Mutex<TcpStreamTLS>>, public_service: Arc<Mutex<PublicService>>, client_service: Arc<Mutex<ClientService>>, client_id: String) {
-    info!("Tunnel handler started.");
-    // sleep for 1 seconds to prevent race condition with healthcheck packet
-    sleep(Duration::from_secs(1)).await;
+// Tunnel Connection
+// To form a bidirectional TCP connection, both server and client must perform
+// different type of operations respectively, for example:
+//   T+0 Server Write
+//   T+1 Client Read
+//   or
+//   T+0 Client Write
+//   T+1 Server Read
+// This behaviour does not allow these operations:
+//   T+0 Server Read
+//   T+1 Client Read
+//   or
+//   T+0 Server Write
+//   T+1 Client Write
+// In a single stream instance, that only makes dead lock on both sides and the connection tracibility is inobvious
+// So, we need to keep the proper sequence like this simulation:
+//   T ..-1  | +0  +1  | +2  +3  | +4  +5  | +6  +7 | +8..
+//   Server  | w       |      r  |      r  |  w     |
+//   Client  |      r  |  w      |  w      |      r |
+//
+// That's why we need to separate the stream into `reader` and `writer`
+// that allows such behaviour as the simulation above
+//
+// TODO: optimize server-client connection
+// Phase 0 (implemented): Full synchronous (decent for a few requests)
+// Phase 1 (implemented): Separate stream writer and reader
+// Phase 2 (might)      : Write data in chunks for all requests (This is also helpful for a large request).
+//                        But, we need to manage it efficiently to avoid any overheads.
+async fn tunnel_sender_handler(stream: Arc<Mutex<TcpStreamTLS>>, public_service: Arc<Mutex<PublicService>>, client_service: Arc<Mutex<ClientService>>, client_id: String) {
+    info!("Tunnel sender handler started.");
+    
+    let mut skip = 0;
     loop {
         // request from the queue
-        let raw_request = public_service.lock().await.dequeue_request(client_id.clone()).await;
-        if let Err(message) = raw_request {
-            // error!("Error getting pending requests: {}", message);
-            // sleep(Duration::from_secs(5)).await;
-            // check connection validity
-            let _ = match send_health_check_packet(stream.clone()).await {
-                Ok(ok) => ok,
-                Err(err) => {
-                    error!("{}", err);
-                    break;
+        match public_service.lock().await.dequeue_request(client_id.clone()).await {
+            Ok(public_request) => {
+                println!("Request was found: {}", public_request.id.clone());
+                
+                // send request to client service
+                let bytes_req = prepare_packet(to_json_vec(&public_request.clone()));
+                let _ = match stream.lock().await.write_all(&bytes_req).await {
+                    Ok(ok) => ok,
+                    Err(err) => {
+                        format!("{}", err);
+                        break;
+                    }
+                };
+
+                info!("Request: {} was sent to client: {}.", public_request.id, public_request.client_id);
+            },
+            Err(_) => {
+                skip += 1;
+                // every 20k skips send health check
+                if skip == 20000 {
+                    let hc = prepare_packet(Vec::from(String::from(HEALTH_CHECK_PACKET_ACK).as_bytes()));
+                    if let Err(_) = stream.lock().await.write_all(&hc).await {
+                        break;
+                    }
+                    // sleep for 0.5 seconds
+                    sleep(Duration::from_millis(100)).await;
+                    skip = 0;
                 }
-            };
-
-            continue;
-        }
-
-        let public_request = raw_request.unwrap();
-        println!("processing: {}", public_request);
-        
-        // send request to client service
-        let bytes_req = to_json_vec(&public_request.clone());
-        let _ = match stream.lock().await.write_all(&bytes_req).await {
-            Ok(ok) => ok,
-            Err(err) => {
-                format!("{}", err);
-                break;
             }
-        };
+        }
+    }
+    
+    // disconnection
+    client_service.lock().await.disconnect_client(client_id.clone()).await.unwrap();
+    info!("Client Disconnected. client_id: {}", client_id);
+}
 
-        info!("Request: {} was sent to client: {}.", public_request.id, public_request.client_id);
+async fn tunnel_receiver_handler(stream: Arc<Mutex<TcpStreamTLS>>, public_service: Arc<Mutex<PublicService>>, client_service: Arc<Mutex<ClientService>>, client_id: String) {
+    info!("Tunnel receiver handler started.");
 
+    loop {
         // get latest response from stream
         let mut raw_response = Vec::new();
         if let Err(e) = read_bytes_from_mutexed_socket(stream.clone(), &mut raw_response).await {
@@ -111,20 +163,28 @@ async fn tunnel_handler(stream: Arc<Mutex<TcpStreamTLS>>, public_service: Arc<Mu
             break;
         }
 
+        // empty response
         if raw_response.len() == 0 {
             continue;
         }
 
-        // enqueue Public Response
-        let response: PublicResponse = from_json_slice(&raw_response).unwrap();
-        let _ = match public_service.lock().await.assign_response(response.clone()).await {
-            Ok(ok) => ok,
-            Err(err) => {
-                break;
-            }
-        };
+        let packets = separate_packets(raw_response);
+        for packet in packets {
+            // enqueue Public Response
+            let response: PublicResponse = match from_json_slice(&packet) {
+                Some(value) => { value },
+                None => {
+                    break;
+                }
+            };
 
-        info!("Response received for request: {}.", response.request_id);
+            if let Err(msg) = public_service.lock().await.assign_response(response.clone()).await {
+                error!("{}", msg);
+                continue;
+            }
+
+            info!("Response received for request: {}.", response.request_id);
+        }
     }
     
     // disconnection

--- a/server/src/handler/tunnel_handler.rs
+++ b/server/src/handler/tunnel_handler.rs
@@ -149,6 +149,7 @@ async fn tunnel_sender_handler(stream: Arc<Mutex<TcpStreamTLS>>, public_service:
     
     // disconnection
     client_service.lock().await.disconnect_client(client_id.clone()).await.unwrap();
+    info!("Tunnel sender handler stopped.");
     info!("Client Disconnected. client_id: {}", client_id);
 }
 
@@ -189,5 +190,6 @@ async fn tunnel_receiver_handler(stream: Arc<Mutex<TcpStreamTLS>>, public_servic
     
     // disconnection
     client_service.lock().await.disconnect_client(client_id.clone()).await.unwrap();
+    info!("Tunnel receiver handler stopped.");
     info!("Client Disconnected. client_id: {}", client_id);
 }

--- a/server/src/service/public_service.rs
+++ b/server/src/service/public_service.rs
@@ -24,20 +24,20 @@ impl PublicService {
 
     // enqueue a public client request to temporary database (redis)
     // the request will further be forwarded to target client service (provider)
-    pub async fn enqueue_request(&self, request: PublicRequest) -> Result<(), String> {
+    pub async fn enqueue_request(&self, client_id: String, request: PublicRequest) -> Result<(), String> {
         // if the request limit is set, the queue len must be checked
         if self.request_limit > 0 {
-            let queue_len = self.request_repo.queue_len(request.client_id.clone()).await?;
+            let queue_len = self.request_repo.queue_len(client_id.clone()).await?;
             if queue_len > self.request_limit {
                 return Err(String::from("Max request limit has been reached"))
             }
         }
 
         // set request as pending
-        (*self.request_repo).ack_pending(request.client_id.clone(), request.id.clone()).await?;
+        (*self.request_repo).ack_pending(client_id.clone(), request.id.clone()).await?;
 
         // enqueue request
-        (*self.request_repo).push_back(request).await
+        (*self.request_repo).push_back(client_id, request).await
     }
 
     // dequeue from request queue (FIFO)
@@ -49,10 +49,15 @@ impl PublicService {
 
     // assign response to hashes mapped by request_id
     // the response is ready to be returned
-    pub async fn assign_response(&self, response: PublicResponse) -> Result<(), String> {
-        (*self.response_repo).set(response).await
+    pub async fn assign_response(&self, client_id: String, response: PublicResponse) -> Result<(), String> {
+        if !(*self.request_repo).is_pending(client_id.clone(), response.request_id.clone()).await {
+            return Err(String::from(format!("Error assigning response for request [{}]: Request invalid/expired", response.request_id.clone())))
+        }
+
+        (*self.response_repo).set(client_id, response).await
     }
 
+    // TODO: implement queue cleaning mechanism
     // get response by corresponding request id
     // it will always check the response until it's found in the cache
     // when the timeout is reached, it breaks and returns a timeout error
@@ -63,7 +68,7 @@ impl PublicService {
         sleep(Duration::from_millis(4)).await;
         loop {
             // check data and return right away if it's found
-            let res = (*self.response_repo).pop(request_id.clone()).await;
+            let res = (*self.response_repo).pop(client_id.clone(), request_id.clone()).await;
             if res.is_ok() {
                 // set request as done
                 (*self.request_repo).ack_done(client_id, request_id).await?;
@@ -77,6 +82,9 @@ impl PublicService {
                 break;
             }
         }
+
+        // set request as done
+        (*self.request_repo).ack_done(client_id, request_id.clone()).await?;
 
         Err(String::from(format!("Error getting request [{}]: Timeout reached after {} seconds", request_id, elapsed)))   
     }

--- a/src/mocks/server/mock_request_repo.rs
+++ b/src/mocks/server/mock_request_repo.rs
@@ -7,44 +7,69 @@ use tokio::sync::Mutex;
 
 
 pub struct MockRequestRepo {
-    mock_request_data: Arc<Mutex<VecDeque<PublicRequest>>>,
-    mock_request_states: Arc<Mutex<HashMap<String, bool>>>,
+    mock_request_data: Arc<Mutex<HashMap<String, VecDeque<PublicRequest>>>>,
+    mock_request_states: Arc<Mutex<HashMap<String, HashMap<String, bool>>>>,
 }
 
 impl MockRequestRepo {
     pub fn new() -> Self {
         MockRequestRepo {
-            mock_request_data: Arc::new(Mutex::new(VecDeque::new())),
-            mock_request_states: Arc::new(Mutex::new(HashMap::<String, bool>::new()))
+            mock_request_data: Arc::new(Mutex::new(HashMap::new())),
+            mock_request_states: Arc::new(Mutex::new(HashMap::new()))
         }
     }
 }
 
 #[async_trait]
 impl RequestRepo for MockRequestRepo {
-    async fn push_back(&self, request: PublicRequest) -> Result<(), String> {
-        self.mock_request_data.lock().await.push_back(request);
+    async fn push_back(&self, client_id: String, request: PublicRequest) -> Result<(), String> {
+        self.mock_request_data.lock().await.entry(client_id)
+            .or_insert_with(VecDeque::new)
+            .push_back(request);
+        
         Ok(())
     }
 
-    async fn pop_front(&self, _: String) -> Result<PublicRequest, String> {
-        if let Some(res) = self.mock_request_data.lock().await.pop_back() {
-            return Ok(res)
+    async fn pop_front(&self, client_id: String) -> Result<PublicRequest, String> {
+        if let Some(queue) = self.mock_request_data.lock().await.get_mut(&client_id) {
+            if let Some(res) = queue.pop_back() {
+                return Ok(res)
+            }
         }
+
         Err(String::from("No request found"))
     }
 
-    async fn queue_len(&self, _: String) -> Result<u16, String> {
-        Ok(self.mock_request_states.lock().await.len() as u16)
+    async fn queue_len(&self, client_id: String) -> Result<u16, String> {
+        if let Some(mp) = self.mock_request_states.lock().await.get_mut(&client_id) {
+            return Ok(mp.len() as u16)
+        }
+
+        Ok(0)
     }
 
-    async fn ack_pending(&self, _: String, request_id: String) -> Result<(), String> {
-        self.mock_request_states.lock().await.insert(request_id, true);
+    async fn ack_pending(&self, client_id: String, request_id: String) -> Result<(), String> {
+        self.mock_request_states.lock().await.entry(client_id)
+            .or_insert_with(HashMap::new)
+            .insert(request_id, true);
         Ok(())
     }
     
-    async fn ack_done(&self, _: String, request_id: String) -> Result<(), String> {
-        self.mock_request_states.lock().await.remove(&request_id);
+    async fn ack_done(&self, client_id: String, request_id: String) -> Result<(), String> {
+        if let Some(mp) = self.mock_request_states.lock().await.get_mut(&client_id) {
+            mp.remove(&request_id);
+        }
+        
         Ok(())
+    }
+
+    async fn is_pending(&self, client_id: String, request_id: String) -> bool {
+        if let Some(mp) = self.mock_request_states.lock().await.get_mut(&client_id) {
+            if let Some(_) = mp.get(&request_id) {
+                return true
+            }
+        }
+        
+        false
     }
 }


### PR DESCRIPTION
**Changes:**
- Improved performance for handling multiple requests

**Benchmark**
Tested with:
50 batches with 40 requests sent and a 400ms delay per batch.

Before:
```
Run 1:
Elapsed time: 66.2148 seconds
request_cnt: 2000
success_cnt:  633

Run 2:
Elapsed time: 66.8324 seconds
request_cnt: 2000
success_cnt:  600

Run 3:
Elapsed time: 66.9765 seconds
request_cnt: 2000
success_cnt:  516
```

After:
```
Run 1:
Elapsed time: 62.5620 seconds
request_cnt: 2000
success_cnt:  1578

Run 2:
Elapsed time: 31.4077 seconds
request_cnt: 2000
success_cnt:  2000

Run 3:
Elapsed time: 45.6027 seconds
request_cnt: 2000
success_cnt:  2000
```

*The time out for each request is 30 seconds, so the unsuccessful ones expire.  It prints the error response, which also affects the overall elapsed time.