### PR TITLE
chore(client svc): stick public endpoints to log header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "lazy_static",
  "log",
  "logtest",
+ "once_cell",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -2057,7 +2058,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "trabas"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = [ "cli", "client", "common", "server"] }
 [package]
 name = "trabas"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,7 +5,7 @@ use log::{self, LevelFilter};
 use once_cell::sync::Lazy;
 use clap::{error::ErrorKind, CommandFactory, Parser, Subcommand};
 use env_logger::{Env, Builder, Target};
-use common::{_info, config::{init_env_from_config, keys::{CONFIG_KEY_GLOBAL_DEBUG, CONFIG_KEY_GLOBAL_LOG_LIMIT}, set_configs}, logger::StickyLogger, version::set_root_version};
+use common::{_info, config::{init_env_from_config, keys::{CONFIG_KEY_GLOBAL_DEBUG, CONFIG_KEY_GLOBAL_LOG_LIMIT}, set_configs}, logger::LOGGER, version::set_root_version};
 use trabas::{PROJECT_NAME, PROJECT_VERSION};
 use ctrlc;
 
@@ -261,11 +261,6 @@ enum ServerCacheActions {
 fn show_version() {
     println!("{} v{}", PROJECT_NAME, PROJECT_VERSION);
 }
-
-// lazy init using once_cell
-static LOGGER: Lazy<StickyLogger> = Lazy::new(|| 
-    StickyLogger::new(10, 
-    std::env::var(CONFIG_KEY_GLOBAL_LOG_LIMIT).unwrap_or("5".to_string()).parse::<usize>().expect("Failed to parse"), false));
 
 fn cleanup_logger_state() {
     if let Ok(mut state) = LOGGER.state.lock() {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,6 +17,7 @@ hmac = "0.12.1"
 http = "1.1.0"
 httparse = "1.9.4"
 log = "0.4.22"
+once_cell = "1.20.3"
 rand = "0.8.5"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"

--- a/server/src/handler/public_handler.rs
+++ b/server/src/handler/public_handler.rs
@@ -180,6 +180,8 @@ async fn public_handler(
         .ok()
         .and_then(|val| val.parse::<u64>().ok())
         .unwrap_or(60); // default timeout is 60 seconds
+    // TODO: check client connection in each iteration of getting response
+    // instead of waiting for the timeout, we break right away if the client is disconnected
     let res = match public_service.get_response(client_id.clone(), request_id.clone(), timeout).await {
         Ok(value) => value,
         Err(msg) => {

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -42,26 +42,30 @@ python3 tests/e2e/run_tests.py
 ## Test Coverage
 
 ### Basic Functionality
-- ✅ **Ping/Pong** - Basic connectivity test
-- ✅ **Path-based routing** - `server:8001/client-id/path`
-- ✅ **Query parameter routing** - `server:8001/path?trabas_client_id=client-id`
+- [x] **Ping/Pong** - Basic connectivity test
+- [x] **Path-based routing** - `server:8001/client-id/path`
+- [x] **Query parameter routing** - `server:8001/path?trabas_client_id=client-id`
 
 ### HTTP Methods
-- ✅ **GET requests** - Various response types
-- ✅ **POST requests** - JSON and text payloads
-- ✅ **PUT requests** - Update operations
-- ✅ **DELETE requests** - Delete operations
+- [x] **GET requests** - Various response types
+- [x] **POST requests** - JSON and text payloads
+- [x] **PUT requests** - Update operations
+- [x] **DELETE requests** - Delete operations
 
 ### Data Handling
-- ✅ **JSON responses** - Structured data
-- ✅ **Headers forwarding** - Custom headers preservation
-- ✅ **Large payloads** - 10KB+ data transmission
-- ✅ **Different status codes** - 200, 201, 400, 500, etc.
+- [x] **JSON responses** - Structured data
+- [x] **Headers forwarding** - Custom headers preservation
+- [x] **Large payloads** - 10KB+ data transmission
+- [x] **Different status codes** - 200, 201, 400, 500, etc.
 
 ### Performance & Reliability
-- ✅ **Slow requests** - 1+ second responses
-- ✅ **Timeout handling** - Request timeout management
-- ✅ **Error scenarios** - Non-existent client IDs
+- [x] **Slow requests** - 1+ second responses
+- [x] **Timeout handling** - Request timeout management
+- [x] **Error scenarios** - Non-existent client IDs
+- [ ] **Resource exhaustion (Stress Test)** - Simulate high load and resource limits
+
+## Scalability Tests
+- [ ] **Multiple Server Instances** - Run multiple Trabas servers (Ofc with redis) and clients
 
 ## Mock Server Endpoints
 


### PR DESCRIPTION
Changes:
- stick the public endpoints returned by server to log header
<img width="982" height="356" alt="image" src="https://github.com/user-attachments/assets/72181b83-7852-4971-8d1d-136cdb01e692" />
