### PR TITLE
security: server sends signature, add proper nonces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,7 +2073,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "trabas"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = [ "cli", "client", "common", "server"] }
 [package]
 name = "trabas"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/client/src/version.rs
+++ b/client/src/version.rs
@@ -4,7 +4,7 @@
 
 use common::version::get_root_version;
 
-const MIN_SERVER_VERSION: &str = "0.1.2-rc.0";
+const MIN_SERVER_VERSION: &str = "0.2.0-beta.2";
 
 pub fn get_client_version() -> String {
     std::env::var("TEST_CLIENT_VERSION")

--- a/common/src/data/dto/tunnel_ack.rs
+++ b/common/src/data/dto/tunnel_ack.rs
@@ -1,8 +1,11 @@
 use serde::{Deserialize, Serialize};
 
+use crate::security::{generate_hmac_key, sign_value};
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct TunnelAck {
-    pub id: String, // tunnel id
+    pub id: String, // tunnel id, as server nonce
+    pub signature: String, // server signature
     pub success: bool,
     pub message: String,
     // public accessible endpoints
@@ -11,17 +14,30 @@ pub struct TunnelAck {
 }
 
 impl TunnelAck {
-    pub fn new(
+    pub fn success(
         id: String,
-        success: bool,
-        message: String,
+        client_mac: String,
+        signing_key: String,
         public_endpoints: Vec<String>,
     ) -> Self {
+        let mac = format!("{}_{}", id, client_mac);
+        let signature = sign_value(mac, signing_key);
         TunnelAck {
             id,
-            success,
-            message,
+            signature,
+            success: true,
+            message: "ok".into(),
             public_endpoints,
+        }
+    }
+
+    pub fn fails(tunnel_id: String, message: String) -> Self {
+        TunnelAck {
+            id: tunnel_id,
+            signature: String::new(),
+            success: false,
+            message,
+            public_endpoints: Vec::new(),
         }
     }
 }

--- a/common/src/data/dto/tunnel_client.rs
+++ b/common/src/data/dto/tunnel_client.rs
@@ -1,4 +1,4 @@
-use crate::security::generate_hmac_key;
+use crate::security::{generate_hmac_key, sign_value};
 use crate::version::validate_version;
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
@@ -26,11 +26,13 @@ pub struct TunnelClient {
 }
 
 impl TunnelClient {
-    pub fn new(id: String, signature: String, cl_version: String, min_sv_version: String) -> Self {
+    pub fn new(id: String, signing_key: String, cl_version: String, min_sv_version: String) -> Self {
+        let alias_id = generate_hmac_key(5); // as client nonce
+        let mac = format!("{}_{}", id, alias_id);
+        let signature = sign_value(mac, signing_key);
         TunnelClient {
             id,
-            // generate alias using a random hex string
-            alias_id: generate_hmac_key(5),
+            alias_id,
             signature,
             cl_version,
             min_sv_version,

--- a/common/tests/test_serialization.rs
+++ b/common/tests/test_serialization.rs
@@ -101,10 +101,10 @@ mod tests {
 
     #[test]
     fn test_tunnel_ack_serialization() {
-        let tunnel_ack = TunnelAck::new(
+        let tunnel_ack = TunnelAck::success(
             "tunnel_123".to_string(),
-            true,
-            "Connection established successfully".to_string(),
+            "client_mac_abc".to_string(),
+            "server_secret_xyz".to_string(),
             vec!["/api/endpoint1".to_string(), "/api/endpoint2".to_string()]
         );
 
@@ -124,11 +124,9 @@ mod tests {
 
     #[test]
     fn test_tunnel_ack_failure_serialization() {
-        let tunnel_ack = TunnelAck::new(
+        let tunnel_ack = TunnelAck::fails(
             "tunnel_456".to_string(),
-            false,
             "Authentication failed".to_string(),
-            vec![] // Empty endpoints for failed connection
         );
 
         let serialized = serde_json::to_string(&tunnel_ack).expect("Failed to serialize TunnelAck");

--- a/server/src/version.rs
+++ b/server/src/version.rs
@@ -4,7 +4,7 @@
 
 use common::version::get_root_version;
 
-const MIN_CLIENT_VERSION: &str = "0.1.2-rc.0";
+const MIN_CLIENT_VERSION: &str = "0.2.0-beta.2";
 
 pub fn get_server_version() -> String {
     std::env::var("TEST_SERVER_VERSION")


### PR DESCRIPTION
Background:
Reduce the risk of MITM attack

Added:
- client side validation: server sends signature to client to validated by client
- proper nonces for signature: adding client alias and tunnel_id as nonces