### PR TITLE
Release Checkpoint: v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,7 +2073,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "trabas"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = [ "cli", "client", "common", "server"] }
 [package]
 name = "trabas"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ Here's how to start tunneling:
 
 Ensure a redis server is available in your system if the `SV_REDIS_ENABLE` config is set to `true`. Then, initialize the config as mentioned [here](./doc/site/src/reference_guide/configuration/server.md).
 Start the service:
-```console
-foo@bar:~$ trabas server run --public-port 8001 --client-port 8002
+```bash
+trabas server run --public-port 8001 --client-port 8002
 ```
 This starts the public request and client service listeners. You may want to limit the number of requests in a time for every request to each client service, just pass the `--client-request-limit [your value]` argument.
 
 **Client Service**
 
 Initialize the config as mentioned [here](./doc/site/src/reference_guide/configuration/client.md). Start the service:
-```console
-foo@bar:~$ trabas client serve --host localhost --port 3000
+```bash
+trabas client serve --host localhost --port 3000
 ```
 this starts the public request and client service listeners.
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Here's the demo showing how the tunneling works using `Trabas`.
 [![Watch the video](https://github.com/user-attachments/assets/47b7397b-45e8-47f5-9296-7f18998cda8e)](https://jotling.liter8.sh/trabas-demo-v1?media=video)
 
 ## Change Logs
-### **v0.2.0** <sub><sup>(pre-release)</sup></sub>
-Native TLS support for server service including SSL key generation, native TLS acceptor, and TOFU (Trust On First Use) option.
+### [**v0.2.0**](https://github.com/amirkode/trabas/releases/tag/trabas-v0.2.0) <sub><sup>(2025-09-06)</sup></sub>
+Added native TLS support for the server (built-in SSL key generation, native TLS acceptor, and TOFU), improved security and public-request handling, and began comprehensive mdBook documentation.
 
 ### [**v0.1.2**](https://github.com/amirkode/trabas/releases/tag/trabas-v0.1.2) <sub><sup>(2025-07-25)</sup></sub>
 Optimized tunnel connection handling (including improved loops, health checks, deadlock prevention, and request distribution). Added version compatibility checks and upstream (underlying service) connection validation.

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -128,7 +128,6 @@ pub fn generate_server_secret(force: bool) -> () {
 }
 
 pub fn generate_ssl_keys(server_config_path: Option<String>, host: Option<String>, ip: Option<String>, force: bool) -> () {
-    // TODO: add TOFU option, without CA
     // generate self-signed SSL keys and saved in trabas_config/ssl
     let base_config_dir = get_config_path();
     let ssl_dir = Path::new(&base_config_dir).join("ssl");

--- a/server/src/handler/tunnel_handler.rs
+++ b/server/src/handler/tunnel_handler.rs
@@ -239,9 +239,11 @@ async fn tunnel_sender_handler(
 
         // make sure of tunnel distribution by dynamically adjusting idle sleep
         // based on the current tunnel count
-        // TODO: review
         // this should simulate Round-robin for multiple tunnels with a single client id
         // despite it's not a strict round-robin, it should be enough
+        // TODO: when we deploy multiple server instances, the tunnel count
+        // should be unique across the instances
+        // need implementation for adding server instance id/key in the client registration
         let acquired_idle_sleep = if curr_tunnel_count > 1 {
             MIN_IDLE_SLEEP * (curr_tunnel_count as u64)
         } else {


### PR DESCRIPTION
Changes:
- TLS Improvement
  - Native TLS acceptor for server service
  - Built-in SSL Keys generation
  - TOFU (Trust On First Use) option for client service
- Other security improvement: 
  - Service Handshake: add signature check from server to client with proper nonces (reducing risk of MITM)
- Public request: add early break on connection closed
- Logging improvements
  - Client: Add show public endpoints on sticky logger
- Doc:
  - Improve contents
  - Init site with mdbook